### PR TITLE
Render checkmarks in Puskesmas ASN PDF

### DIFF
--- a/resources/views/pdf/surat-cuti-puskesmas-asn.blade.php
+++ b/resources/views/pdf/surat-cuti-puskesmas-asn.blade.php
@@ -87,13 +87,8 @@
             display: inline-block;
             margin-right: 5px;
             vertical-align: middle;
-        }
-        
-        .checkbox.checked::after {
-            content: '✓';
-            display: block;
             text-align: center;
-            line-height: 11px;
+            line-height: 13px;
             font-weight: bold;
         }
         
@@ -370,19 +365,19 @@
             @endphp
             <tr>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanAtasan == 'disetujui' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanAtasan == 'disetujui' ? '✓' : '' }}</span>
                     <strong>DISETUJUI</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanAtasan == 'perubahan' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanAtasan == 'perubahan' ? '✓' : '' }}</span>
                     <strong>PERUBAHAN</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanAtasan == 'ditangguhkan' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanAtasan == 'ditangguhkan' ? '✓' : '' }}</span>
                     <strong>DITANGGUHKAN</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanAtasan == 'tidak_disetujui' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanAtasan == 'tidak_disetujui' ? '✓' : '' }}</span>
                     <strong>TIDAK DISETUJUI</strong>
                 </td>
             </tr>
@@ -427,19 +422,19 @@
             @endphp
             <tr>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanKepala == 'disetujui' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanKepala == 'disetujui' ? '✓' : '' }}</span>
                     <strong>DISETUJUI</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanKepala == 'perubahan' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanKepala == 'perubahan' ? '✓' : '' }}</span>
                     <strong>PERUBAHAN</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanKepala == 'ditangguhkan' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanKepala == 'ditangguhkan' ? '✓' : '' }}</span>
                     <strong>DITANGGUHKAN</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanKepala == 'tidak_disetujui' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanKepala == 'tidak_disetujui' ? '✓' : '' }}</span>
                     <strong>TIDAK DISETUJUI</strong>
                 </td>
             </tr>


### PR DESCRIPTION
### **User description**
## Summary
- Ensure 'DISETUJUI' options render a visible checkmark in the Puskesmas ASN PDF template
- Simplify checkbox CSS by removing pseudo-element usage

## Testing
- `./vendor/bin/pint resources/views/pdf/surat-cuti-puskesmas-asn.blade.php`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68a695aef9ac8320833a959f63b181c2


___

### **PR Type**
Bug fix


___

### **Description**
- Fix checkbox rendering in PDF by replacing CSS pseudo-elements with direct content

- Ensure checkmarks display properly for approved leave requests

- Simplify checkbox styling for better PDF compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CSS Pseudo-element"] -- "Replace with" --> B["Direct Content"]
  B -- "Renders" --> C["Visible Checkmarks"]
  C -- "In" --> D["PDF Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>surat-cuti-puskesmas-asn.blade.php</strong><dd><code>Fix PDF checkbox rendering implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/views/pdf/surat-cuti-puskesmas-asn.blade.php

<ul><li>Remove CSS pseudo-element styling for checked checkboxes<br> <li> Replace conditional CSS classes with direct checkmark content<br> <li> Adjust line-height for better checkbox alignment<br> <li> Apply changes to both supervisor and authority decision sections</ul>


</details>


  </td>
  <td><a href="https://github.com/alfarizi-front/laravel-surat-cuti/pull/3/files#diff-a40184b31d3feec85b22a3df04baeffc0eb5be884e681328c6c2abc057e95233">+9/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

