### PR TITLE
Render checkmarks in Puskesmas ASN PDF

### DIFF
--- a/resources/views/pdf/pdf_pppk.blade.php
+++ b/resources/views/pdf/pdf_pppk.blade.php
@@ -80,6 +80,18 @@
             margin-top: 0;
             color: #2c5aa0;
         }
+        .checkbox {
+            width: 15px;
+            height: 15px;
+            border: 2px solid #000;
+            display: inline-block;
+            margin-right: 5px;
+            vertical-align: middle;
+            text-align: center;
+            line-height: 13px;
+            font-weight: bold;
+            font-family: 'DejaVu Sans', sans-serif;
+        }
         @page {
             margin: 1cm;
         }
@@ -168,9 +180,12 @@
                     <td>{{ $d->user->nama ?? '-' }}</td>
                     <td>{{ $d->jabatan }}</td>
                     <td style="text-align:center;">
-                        @if($d->status === 'sudah') DISETUJUI
-                        @elseif($d->status === 'ditolak') DITOLAK
-                        @else PENDING
+                        @if($d->status === 'sudah')
+                            <span class="checkbox">✓</span> DISETUJUI
+                        @elseif($d->status === 'ditolak')
+                            DITOLAK
+                        @else
+                            PENDING
                         @endif
                     </td>
                     <td style="text-align:center;">{{ $d->tanggal ? $d->tanggal->format('d/m/Y') : '-' }}</td>

--- a/resources/views/pdf/surat-cuti-bidang.blade.php
+++ b/resources/views/pdf/surat-cuti-bidang.blade.php
@@ -110,6 +110,19 @@
             vertical-align: middle;
         }
 
+        .checkbox {
+            width: 15px;
+            height: 15px;
+            border: 2px solid #000;
+            display: inline-block;
+            margin-right: 5px;
+            vertical-align: middle;
+            text-align: center;
+            line-height: 13px;
+            font-weight: bold;
+            font-family: 'DejaVu Sans', sans-serif;
+        }
+
         .footer {
             margin-top: 20px;
             text-align: center;
@@ -119,24 +132,6 @@
             padding-top: 10px;
         }
 
-        .checkbox {
-            width: 15px;
-            height: 15px;
-            border: 2px solid #000;
-            display: inline-block;
-            margin-right: 8px;
-            vertical-align: middle;
-            text-align: center;
-            line-height: 11px;
-            font-weight: bold;
-            background-color: white;
-        }
-
-        .checkbox.checked {
-            background-color: white;
-            color: black;
-            font-weight: bold;
-        }
 
         @page {
             margin: 2cm;
@@ -307,7 +302,7 @@
                 <td>{{ $disposisi->user ? $disposisi->user->nama : 'N/A' }}</td>
                 <td>
                     @if($disposisi->status === 'sudah')
-                        <span style="color: #000; font-weight: bold;">DISETUJUI</span>
+                        <span style="color: #000; font-weight: bold;"><span class="checkbox">✓</span>DISETUJUI</span>
                     @else
                         <span style="color: #666;">PENDING</span>
                     @endif
@@ -353,7 +348,7 @@
                         @endphp
 
                         @if($ttd->status === 'sudah')
-                            <div style="color: #000; font-weight: bold; margin-bottom: 5px;">DISETUJUI</div>
+                            <div style="color: #000; font-weight: bold; margin-bottom: 5px;"><span class="checkbox">✓</span>DISETUJUI</div>
                             <div style="font-size: 10px;">{{ $ttd->tanggal ? $ttd->tanggal->format('d F Y') : '' }}</div>
 
                             @if($ttdSignature && ($ttdSignature->signature_path || $ttdSignature->stamp_path))
@@ -396,7 +391,7 @@
                         @endphp
 
                         @if($ttd->status === 'sudah')
-                            <div style="color: #000; font-weight: bold; margin-bottom: 5px;">DISETUJUI</div>
+                            <div style="color: #000; font-weight: bold; margin-bottom: 5px;"><span class="checkbox">✓</span>DISETUJUI</div>
                             <div style="font-size: 10px;">{{ $ttd->tanggal ? $ttd->tanggal->format('d F Y') : '' }}</div>
 
                             @if($ttdSignature && ($ttdSignature->signature_path || $ttdSignature->stamp_path))

--- a/resources/views/pdf/surat-cuti-puskesmas-asn.blade.php
+++ b/resources/views/pdf/surat-cuti-puskesmas-asn.blade.php
@@ -87,14 +87,10 @@
             display: inline-block;
             margin-right: 5px;
             vertical-align: middle;
-        }
-        
-        .checkbox.checked::after {
-            content: '✓';
-            display: block;
             text-align: center;
-            line-height: 11px;
+            line-height: 13px;
             font-weight: bold;
+            font-family: 'DejaVu Sans', sans-serif;
         }
         
         .signature-section {
@@ -366,23 +362,23 @@
             @php
                 $atasanLangsung = $disposisiList->where('jabatan', 'like', '%Kepala Puskesmas%')->first() ??
                                  $disposisiList->where('jabatan', 'like', '%Kepala%')->first();
-                $keputusanAtasan = $atasanLangsung ? ($atasanLangsung->status === 'sudah' ? 'disetujui' : 'pending') : 'pending';
+                $keputusanAtasan = $pertimbangan_atasan ?? ($suratCuti->pertimbangan_atasan ?? '');
             @endphp
             <tr>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanAtasan == 'disetujui' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanAtasan == 'disetujui' ? '✓' : '' }}</span>
                     <strong>DISETUJUI</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanAtasan == 'perubahan' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanAtasan == 'perubahan' ? '✓' : '' }}</span>
                     <strong>PERUBAHAN</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanAtasan == 'ditangguhkan' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanAtasan == 'ditangguhkan' ? '✓' : '' }}</span>
                     <strong>DITANGGUHKAN</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanAtasan == 'tidak_disetujui' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanAtasan == 'tidak_disetujui' ? '✓' : '' }}</span>
                     <strong>TIDAK DISETUJUI</strong>
                 </td>
             </tr>
@@ -423,23 +419,23 @@
         <tbody>
             @php
                 $kadin = $disposisiList->where('jabatan', 'KADIN')->first();
-                $keputusanKepala = $kadin ? ($kadin->status === 'sudah' ? 'disetujui' : 'pending') : 'pending';
+                $keputusanKepala = $keputusan_pejabat ?? ($suratCuti->keputusan_pejabat ?? '');
             @endphp
             <tr>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanKepala == 'disetujui' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanKepala == 'disetujui' ? '✓' : '' }}</span>
                     <strong>DISETUJUI</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanKepala == 'perubahan' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanKepala == 'perubahan' ? '✓' : '' }}</span>
                     <strong>PERUBAHAN</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanKepala == 'ditangguhkan' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanKepala == 'ditangguhkan' ? '✓' : '' }}</span>
                     <strong>DITANGGUHKAN</strong>
                 </td>
                 <td style="width: 25%;">
-                    <span class="checkbox {{ $keputusanKepala == 'tidak_disetujui' ? 'checked' : '' }}"></span>
+                    <span class="checkbox">{{ $keputusanKepala == 'tidak_disetujui' ? '✓' : '' }}</span>
                     <strong>TIDAK DISETUJUI</strong>
                 </td>
             </tr>

--- a/resources/views/pdf/surat-cuti-puskesmas.blade.php
+++ b/resources/views/pdf/surat-cuti-puskesmas.blade.php
@@ -103,6 +103,19 @@
             padding: 10px;
             font-weight: bold;
         }
+
+        .checkbox {
+            width: 15px;
+            height: 15px;
+            border: 2px solid #000;
+            display: inline-block;
+            margin-right: 5px;
+            vertical-align: middle;
+            text-align: center;
+            line-height: 13px;
+            font-weight: bold;
+            font-family: 'DejaVu Sans', sans-serif;
+        }
         
         .watermark {
             position: fixed;
@@ -263,7 +276,7 @@
                 <td>{{ $disposisi->user->nama ?? 'N/A' }}</td>
                 <td>
                     @if($disposisi->status === 'sudah')
-                        <span style="color: #059669; font-weight: bold;">✅ APPROVED</span>
+                        <span style="color: #059669; font-weight: bold;"><span class="checkbox">✓</span> APPROVED</span>
                     @else
                         <span style="color: #d97706; font-weight: bold;">⏳ PENDING</span>
                     @endif
@@ -292,7 +305,7 @@
                     </div>
                     <div style="height: 80px; margin: 20px 0;">
                         @if($ttd->status === 'sudah')
-                            <div style="color: #059669; font-weight: bold; margin-bottom: 10px;">✅ DISETUJUI</div>
+                            <div style="color: #059669; font-weight: bold; margin-bottom: 10px;"><span class="checkbox">✓</span> DISETUJUI</div>
                             <div style="font-size: 10px;">{{ $ttd->tanggal ? $ttd->tanggal->format('d F Y') : '' }}</div>
                         @else
                             <div style="color: #d97706; font-style: italic;">( Menunggu Tanda Tangan )</div>
@@ -312,7 +325,7 @@
                     </div>
                     <div style="height: 80px; margin: 20px 0;">
                         @if($ttd->status === 'sudah')
-                            <div style="color: #059669; font-weight: bold; margin-bottom: 10px;">✅ DISETUJUI</div>
+                            <div style="color: #059669; font-weight: bold; margin-bottom: 10px;"><span class="checkbox">✓</span> DISETUJUI</div>
                             <div style="font-size: 10px;">{{ $ttd->tanggal ? $ttd->tanggal->format('d F Y') : '' }}</div>
                             @if($ttd->catatan)
                                 <div style="font-size: 9px; color: #6b7280; margin-top: 5px;">{{ $ttd->catatan }}</div>

--- a/resources/views/pdf/surat-cuti-sekretariat.blade.php
+++ b/resources/views/pdf/surat-cuti-sekretariat.blade.php
@@ -134,6 +134,7 @@
             line-height: 11px;
             font-weight: bold;
             background-color: white;
+            font-family: 'DejaVu Sans', sans-serif;
         }
 
         .checkbox.checked {
@@ -366,7 +367,7 @@
                 <td>{{ $disposisi->user->nama ?? 'N/A' }}</td>
                 <td>
                     @if($disposisi->status === 'sudah')
-                        <span style="color: #059669; font-weight: bold;">✅ APPROVED</span>
+                        <span style="color: #059669; font-weight: bold;"><span class="checkbox">✓</span> APPROVED</span>
                     @else
                         <span style="color: #d97706; font-weight: bold;">⏳ PENDING</span>
                     @endif
@@ -395,7 +396,7 @@
                     </div>
                     <div style="height: 80px; margin: 20px 0;">
                         @if($ttd->status === 'sudah')
-                            <div style="color: #059669; font-weight: bold; margin-bottom: 10px;">✅ DISETUJUI</div>
+                            <div style="color: #059669; font-weight: bold; margin-bottom: 10px;"><span class="checkbox">✓</span> DISETUJUI</div>
                             <div style="font-size: 10px;">{{ $ttd->tanggal ? $ttd->tanggal->format('d F Y') : '' }}</div>
                         @else
                             <div style="color: #d97706; font-style: italic;">( Menunggu Tanda Tangan )</div>
@@ -419,7 +420,7 @@
                     </div>
                     <div style="height: 80px; margin: 20px 0;">
                         @if($ttd->status === 'sudah')
-                            <div style="color: #059669; font-weight: bold; margin-bottom: 10px;">✅ DISETUJUI</div>
+                            <div style="color: #059669; font-weight: bold; margin-bottom: 10px;"><span class="checkbox">✓</span> DISETUJUI</div>
                             <div style="font-size: 10px;">{{ $ttd->tanggal ? $ttd->tanggal->format('d F Y') : '' }}</div>
                             @if($ttd->catatan)
                                 <div style="font-size: 9px; color: #6b7280; margin-top: 5px;">{{ $ttd->catatan }}</div>


### PR DESCRIPTION
## Summary
- Ensure checkboxes use a DejaVu Sans font so ticks show up in generated PDFs
- Read approval status from `pertimbangan_atasan` and `keputusan_pejabat` when rendering Puskesmas ASN checkboxes

## Testing
- `./vendor/bin/pint resources/views/pdf/pdf_pppk.blade.php resources/views/pdf/surat-cuti-bidang.blade.php resources/views/pdf/surat-cuti-puskesmas-asn.blade.php resources/views/pdf/surat-cuti-puskesmas.blade.php resources/views/pdf/surat-cuti-sekretariat.blade.php`
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a695aef9ac8320833a959f63b181c2