### PR TITLE
Add admin management for Puskesmas signatures

### DIFF
--- a/app/Http/Controllers/Admin/PuskesmasController.php
+++ b/app/Http/Controllers/Admin/PuskesmasController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Puskesmas;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class PuskesmasController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'role:admin']);
+    }
+
+    public function index()
+    {
+        $puskesmas = Puskesmas::orderBy('nama')->get();
+
+        return view('admin.puskesmas.index', compact('puskesmas'));
+    }
+
+    public function edit(Puskesmas $puskesma)
+    {
+        return view('admin.puskesmas.edit', compact('puskesma'));
+    }
+
+    public function update(Request $request, Puskesmas $puskesma)
+    {
+        $data = $request->validate([
+            'kepala_puskesmas' => 'nullable|string|max:255',
+            'nip_kepala' => 'nullable|string|max:20',
+            'tanda_tangan' => 'nullable|image|mimes:png,jpg,jpeg|max:1024',
+            'cap_stempel' => 'nullable|image|mimes:png,jpg,jpeg|max:1024',
+        ]);
+
+        if ($request->hasFile('tanda_tangan')) {
+            if ($puskesma->tanda_tangan && Storage::disk('public')->exists($puskesma->tanda_tangan)) {
+                Storage::disk('public')->delete($puskesma->tanda_tangan);
+            }
+            $data['tanda_tangan'] = $request->file('tanda_tangan')->store('puskesmas/signatures', 'public');
+        }
+
+        if ($request->hasFile('cap_stempel')) {
+            if ($puskesma->cap_stempel && Storage::disk('public')->exists($puskesma->cap_stempel)) {
+                Storage::disk('public')->delete($puskesma->cap_stempel);
+            }
+            $data['cap_stempel'] = $request->file('cap_stempel')->store('puskesmas/cap', 'public');
+        }
+
+        $puskesma->update($data);
+
+        return redirect()->route('admin.puskesmas.index')->with('success', 'Data puskesmas diperbarui');
+    }
+}

--- a/app/Models/Puskesmas.php
+++ b/app/Models/Puskesmas.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Puskesmas extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'nama',
+        'kepala_puskesmas',
+        'nip_kepala',
+        'tanda_tangan',
+        'cap_stempel',
+    ];
+}

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateUsersTable extends Migration
 {
     /**
      * Run the migrations.
@@ -50,4 +50,4 @@ return new class extends Migration
         Schema::dropIfExists('password_reset_tokens');
         Schema::dropIfExists('sessions');
     }
-};
+}

--- a/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateCacheTable extends Migration
 {
     /**
      * Run the migrations.
@@ -32,4 +32,4 @@ return new class extends Migration
         Schema::dropIfExists('cache');
         Schema::dropIfExists('cache_locks');
     }
-};
+}

--- a/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateJobsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -54,4 +54,4 @@ return new class extends Migration
         Schema::dropIfExists('job_batches');
         Schema::dropIfExists('failed_jobs');
     }
-};
+}

--- a/database/migrations/2024_01_01_000003_create_jenis_cuti_table.php
+++ b/database/migrations/2024_01_01_000003_create_jenis_cuti_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateJenisCutiTable extends Migration
 {
     /**
      * Run the migrations.
@@ -26,4 +26,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('jenis_cuti');
     }
-};
+}

--- a/database/migrations/2024_01_01_000004_create_alur_cuti_table.php
+++ b/database/migrations/2024_01_01_000004_create_alur_cuti_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateAlurCutiTable extends Migration
 {
     /**
      * Run the migrations.
@@ -29,4 +29,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('alur_cuti');
     }
-};
+}

--- a/database/migrations/2024_01_01_000005_create_surat_cuti_table.php
+++ b/database/migrations/2024_01_01_000005_create_surat_cuti_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateSuratCutiTable extends Migration
 {
     /**
      * Run the migrations.
@@ -34,4 +34,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('surat_cuti');
     }
-};
+}

--- a/database/migrations/2024_01_01_000006_create_disposisi_cuti_table.php
+++ b/database/migrations/2024_01_01_000006_create_disposisi_cuti_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateDisposisiCutiTable extends Migration
 {
     /**
      * Run the migrations.
@@ -30,4 +30,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('disposisi_cuti');
     }
-};
+}

--- a/database/migrations/2024_01_01_000007_add_signature_to_users_table.php
+++ b/database/migrations/2024_01_01_000007_add_signature_to_users_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class AddSignatureToUsersTable extends Migration
 {
     /**
      * Run the migrations.
@@ -26,4 +26,4 @@ return new class extends Migration
             $table->dropColumn(['tanda_tangan', 'nip']);
         });
     }
-};
+}

--- a/database/migrations/2024_01_01_000010_create_cuti_tahunan_table.php
+++ b/database/migrations/2024_01_01_000010_create_cuti_tahunan_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateCutiTahunanTable extends Migration
 {
     /**
      * Run the migrations.
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->integer('cuti_pending')->default(0); // Cuti yang sedang pending
             $table->integer('sisa_cuti')->default(12); // Sisa cuti yang tersedia
             $table->timestamps();
-            
+
             // Unique constraint untuk user dan tahun
             $table->unique(['user_id', 'tahun']);
         });
@@ -33,4 +33,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('cuti_tahunan');
     }
-};
+}

--- a/database/migrations/2024_01_01_000011_add_cap_stempel_to_users_table.php
+++ b/database/migrations/2024_01_01_000011_add_cap_stempel_to_users_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class AddCapStempelToUsersTable extends Migration
 {
     /**
      * Run the migrations.
@@ -26,4 +26,4 @@ return new class extends Migration
             $table->dropColumn(['cap_stempel', 'gunakan_cap']);
         });
     }
-};
+}

--- a/database/migrations/2024_01_01_000012_create_atasan_setup_table.php
+++ b/database/migrations/2024_01_01_000012_create_atasan_setup_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateAtasanSetupTable extends Migration
 {
     /**
      * Run the migrations.
@@ -37,9 +37,9 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('atasan_setup');
-        
+
         Schema::table('users', function (Blueprint $table) {
             $table->dropColumn(['signature_setup_completed', 'signature_setup_at']);
         });
     }
-};
+}

--- a/database/migrations/2024_12_08_000001_remove_duplicate_disposisi_and_add_unique_constraint.php
+++ b/database/migrations/2024_12_08_000001_remove_duplicate_disposisi_and_add_unique_constraint.php
@@ -2,10 +2,10 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class RemoveDuplicateDisposisiAndAddUniqueConstraint extends Migration
 {
     /**
      * Run the migrations.
@@ -14,14 +14,14 @@ return new class extends Migration
     {
         // Remove duplicate disposisi entries
         $this->removeDuplicateDisposisi();
-        
+
         // Add unique constraint to prevent future duplicates
         Schema::table('disposisi_cuti', function (Blueprint $table) {
             $table->unique(['surat_cuti_id', 'user_id', 'jabatan'], 'unique_disposisi');
         });
-        
+
         // Add missing tipe_disposisi column if it doesn't exist
-        if (!Schema::hasColumn('disposisi_cuti', 'tipe_disposisi')) {
+        if (! Schema::hasColumn('disposisi_cuti', 'tipe_disposisi')) {
             Schema::table('disposisi_cuti', function (Blueprint $table) {
                 $table->enum('tipe_disposisi', ['paraf', 'ttd'])->default('paraf')->after('jabatan');
             });
@@ -40,7 +40,7 @@ return new class extends Migration
             }
         });
     }
-    
+
     /**
      * Remove duplicate disposisi entries, keeping only the first occurrence
      */
@@ -61,14 +61,14 @@ return new class extends Migration
                 ->where('jabatan', $duplicate->jabatan)
                 ->where('id', '!=', $duplicate->keep_id)
                 ->delete();
-                
-            echo "Removed " . ($duplicate->count - 1) . " duplicate(s) for surat_cuti_id: {$duplicate->surat_cuti_id}, user_id: {$duplicate->user_id}, jabatan: {$duplicate->jabatan}\n";
+
+            echo 'Removed '.($duplicate->count - 1)." duplicate(s) for surat_cuti_id: {$duplicate->surat_cuti_id}, user_id: {$duplicate->user_id}, jabatan: {$duplicate->jabatan}\n";
         }
-        
+
         if ($duplicates->count() > 0) {
-            echo "Successfully removed duplicates for " . $duplicates->count() . " disposisi groups.\n";
+            echo 'Successfully removed duplicates for '.$duplicates->count()." disposisi groups.\n";
         } else {
             echo "No duplicate disposisi entries found.\n";
         }
     }
-};
+}

--- a/database/migrations/2025_08_13_015858_create_puskesmas_table.php
+++ b/database/migrations/2025_08_13_015858_create_puskesmas_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreatePuskesmasTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,6 +13,11 @@ return new class extends Migration
     {
         Schema::create('puskesmas', function (Blueprint $table) {
             $table->id();
+            $table->string('nama');
+            $table->string('kepala_puskesmas')->nullable();
+            $table->string('nip_kepala')->nullable();
+            $table->string('tanda_tangan')->nullable();
+            $table->string('cap_stempel')->nullable();
             $table->timestamps();
         });
     }
@@ -24,4 +29,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('puskesmas');
     }
-};
+}

--- a/database/migrations/2025_08_13_015959_add_puskesmas_id_to_users_table.php
+++ b/database/migrations/2025_08_13_015959_add_puskesmas_id_to_users_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class AddPuskesmasIdToUsersTable extends Migration
 {
     /**
      * Run the migrations.
@@ -25,4 +25,4 @@ return new class extends Migration
             //
         });
     }
-};
+}

--- a/database/migrations/2025_08_15_034425_add_additional_fields_to_users_table.php
+++ b/database/migrations/2025_08_15_034425_add_additional_fields_to_users_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class AddAdditionalFieldsToUsersTable extends Migration
 {
     /**
      * Run the migrations.
@@ -29,4 +29,4 @@ return new class extends Migration
             $table->dropColumn(['alamat', 'telepon', 'masa_kerja', 'golongan', 'pangkat']);
         });
     }
-};
+}

--- a/database/migrations/2025_08_15_040835_create_signatures_table.php
+++ b/database/migrations/2025_08_15_040835_create_signatures_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateSignaturesTable extends Migration
 {
     /**
      * Run the migrations.
@@ -31,4 +31,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('signatures');
     }
-};
+}

--- a/database/migrations/2025_08_15_063028_create_sisa_cuti_table.php
+++ b/database/migrations/2025_08_15_063028_create_sisa_cuti_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateSisaCutiTable extends Migration
 {
     /**
      * Run the migrations.
@@ -34,4 +34,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('sisa_cuti');
     }
-};
+}

--- a/database/migrations/2025_08_20_000001_add_golongan_ruang_masa_jabatan_to_surat_cuti_table.php
+++ b/database/migrations/2025_08_20_000001_add_golongan_ruang_masa_jabatan_to_surat_cuti_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class AddGolonganRuangMasaJabatanToSuratCutiTable extends Migration
 {
     /**
      * Run the migrations.
@@ -26,7 +26,4 @@ return new class extends Migration
             $table->dropColumn(['golongan_ruang', 'masa_jabatan']);
         });
     }
-};
-
-
-
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Seeder;
 
 /**
  * DatabaseSeeder
- * 
+ *
  * Main seeder that orchestrates all database seeding operations.
  * Runs seeders in the correct order to maintain referential integrity.
  */
@@ -23,6 +23,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             JenisCutiSeeder::class,
             AlurCutiSeeder::class,
+            PuskesmasSeeder::class,
         ]);
 
         // User data

--- a/database/seeders/PuskesmasSeeder.php
+++ b/database/seeders/PuskesmasSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Puskesmas;
+use Illuminate\Database\Seeder;
+
+class PuskesmasSeeder extends Seeder
+{
+    public function run(): void
+    {
+        for ($i = 1; $i <= 27; $i++) {
+            Puskesmas::create([
+                'nama' => 'Puskesmas '.$i,
+            ]);
+        }
+    }
+}

--- a/resources/views/admin/puskesmas/edit.blade.php
+++ b/resources/views/admin/puskesmas/edit.blade.php
@@ -1,0 +1,49 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">Edit Kepala - {{ $puskesma->nama }}</h3>
+                </div>
+                <div class="card-body">
+                    <form action="{{ route('admin.puskesmas.update', $puskesma) }}" method="POST" enctype="multipart/form-data">
+                        @csrf
+                        @method('PUT')
+                        <div class="form-group">
+                            <label>Nama Kepala Puskesmas</label>
+                            <input type="text" name="kepala_puskesmas" class="form-control" value="{{ old('kepala_puskesmas', $puskesma->kepala_puskesmas) }}">
+                        </div>
+                        <div class="form-group">
+                            <label>NIP Kepala</label>
+                            <input type="text" name="nip_kepala" class="form-control" value="{{ old('nip_kepala', $puskesma->nip_kepala) }}">
+                        </div>
+                        <div class="form-group">
+                            <label>Tanda Tangan</label>
+                            @if($puskesma->tanda_tangan)
+                                <div class="mb-2">
+                                    <img src="{{ asset('storage/'.$puskesma->tanda_tangan) }}" alt="ttd" style="max-height:80px;">
+                                </div>
+                            @endif
+                            <input type="file" name="tanda_tangan" class="form-control-file">
+                        </div>
+                        <div class="form-group">
+                            <label>Cap / Stempel</label>
+                            @if($puskesma->cap_stempel)
+                                <div class="mb-2">
+                                    <img src="{{ asset('storage/'.$puskesma->cap_stempel) }}" alt="cap" style="max-height:80px;">
+                                </div>
+                            @endif
+                            <input type="file" name="cap_stempel" class="form-control-file">
+                        </div>
+                        <button type="submit" class="btn btn-primary">Simpan</button>
+                        <a href="{{ route('admin.puskesmas.index') }}" class="btn btn-secondary">Kembali</a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/puskesmas/index.blade.php
+++ b/resources/views/admin/puskesmas/index.blade.php
@@ -1,0 +1,72 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h3 class="card-title">
+                        <i class="fas fa-clinic-medical mr-2"></i>
+                        Kepala Puskesmas
+                    </h3>
+                </div>
+                <div class="card-body">
+                    @if(session('success'))
+                        <div class="alert alert-success alert-dismissible fade show" role="alert">
+                            {{ session('success') }}
+                            <button type="button" class="close" data-dismiss="alert">
+                                <span>&times;</span>
+                            </button>
+                        </div>
+                    @endif
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-striped">
+                            <thead class="thead-dark">
+                                <tr>
+                                    <th width="5%">#</th>
+                                    <th width="25%">Puskesmas</th>
+                                    <th width="20%">Kepala</th>
+                                    <th width="15%">NIP</th>
+                                    <th width="15%">Tanda Tangan</th>
+                                    <th width="15%">Cap</th>
+                                    <th width="5%">Aksi</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($puskesmas as $item)
+                                    <tr>
+                                        <td>{{ $loop->iteration }}</td>
+                                        <td>{{ $item->nama }}</td>
+                                        <td>{{ $item->kepala_puskesmas ?? '-' }}</td>
+                                        <td>{{ $item->nip_kepala ?? '-' }}</td>
+                                        <td class="text-center">
+                                            @if($item->tanda_tangan)
+                                                <img src="{{ asset('storage/'.$item->tanda_tangan) }}" alt="ttd" style="max-height:40px;">
+                                            @else
+                                                <span class="text-muted">-</span>
+                                            @endif
+                                        </td>
+                                        <td class="text-center">
+                                            @if($item->cap_stempel)
+                                                <img src="{{ asset('storage/'.$item->cap_stempel) }}" alt="cap" style="max-height:40px;">
+                                            @else
+                                                <span class="text-muted">-</span>
+                                            @endif
+                                        </td>
+                                        <td>
+                                            <a href="{{ route('admin.puskesmas.edit', $item) }}" class="btn btn-sm btn-warning">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -82,6 +82,10 @@
                             <i class="fas fa-stamp mr-2"></i>
                             {{ __('Cap & Tanda Tangan') }}
                         </x-nav-link>
+                        <x-nav-link :href="route('admin.puskesmas.index')" :active="request()->routeIs('admin.puskesmas.*')" class="nav-item">
+                            <i class="fas fa-clinic-medical mr-2"></i>
+                            {{ __('Kepala Puskesmas') }}
+                        </x-nav-link>
                     @endif
                 </div>
             </div>
@@ -182,6 +186,9 @@
                 </x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('admin.cap-stempel.index')" :active="request()->routeIs('admin.cap-stempel.*')">
                     {{ __('Cap & Tanda Tangan') }}
+                </x-responsive-nav-link>
+                <x-responsive-nav-link :href="route('admin.puskesmas.index')" :active="request()->routeIs('admin.puskesmas.*')">
+                    {{ __('Kepala Puskesmas') }}
                 </x-responsive-nav-link>
             @endif
         </div>

--- a/resources/views/pdf/pdf_puskesmas.blade.php
+++ b/resources/views/pdf/pdf_puskesmas.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Surat Cuti - {{ $puskesmas->nama_puskesmas ?? 'Puskesmas' }}</title>
+    <title>Surat Cuti - {{ $puskesmas->nama ?? 'Puskesmas' }}</title>
     <style>
         body { font-family: Arial, sans-serif; font-size: 12pt; line-height: 1.4; margin: 20px; }
         .header-section { display: flex; justify-content: space-between; margin-bottom: 20px; }
@@ -42,7 +42,7 @@
 <body>
 @php
     // Data Puskesmas
-    $puskesmasNama = $puskesmas->nama_puskesmas ?? 'Puskesmas';
+    $puskesmasNama = $puskesmas->nama ?? 'Puskesmas';
     $puskesmasAlamat = $puskesmas->alamat ?? '';
     $kepalaPuskesmas = $puskesmas->kepala_puskesmas_lengkap ?? $puskesmas->kepala_puskesmas ?? '[Kepala Puskesmas]';
     $nipKepala = $puskesmas->nip_kepala ?? '[NIP Kepala]';

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,9 @@
 <?php
 
 use App\Http\Controllers\DashboardController;
-use App\Http\Controllers\SuratCutiController;
 use App\Http\Controllers\DisposisiController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\SuratCutiController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -18,8 +18,8 @@ use Illuminate\Support\Facades\Route;
 */
 
 // Public routes
-Route::get('/', fn() => view('welcome'));
-Route::get('/test', fn() => 'Laravel is working!');
+Route::get('/', fn () => view('welcome'));
+Route::get('/test', fn () => 'Laravel is working!');
 
 // Authentication routes
 Route::get('/register', [\App\Http\Controllers\Auth\RegisterController::class, 'showRegistrationForm'])->name('register');
@@ -35,7 +35,7 @@ if (app()->environment('local')) {
 
 // Authenticated routes
 Route::middleware('auth')->group(function () {
-    
+
     // Core application routes
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
@@ -91,7 +91,7 @@ Route::middleware('auth')->group(function () {
 
     // Admin panel
     Route::prefix('admin')->name('admin.')->middleware('role:admin,kadin')->group(function () {
-        
+
         // User management
         Route::resource('users', \App\Http\Controllers\Admin\UserManagementController::class);
 
@@ -114,6 +114,8 @@ Route::middleware('auth')->group(function () {
             Route::post('/bulk-upload', [\App\Http\Controllers\Admin\CapStempelController::class, 'bulkUpload'])->name('bulk-upload');
         });
 
+        Route::resource('puskesmas', \App\Http\Controllers\Admin\PuskesmasController::class)->only(['index', 'edit', 'update']);
+
         // Signature management
         Route::prefix('signatures')->name('signatures.')->group(function () {
             Route::get('/', [\App\Http\Controllers\Admin\SignatureController::class, 'index'])->name('index');
@@ -135,8 +137,8 @@ Route::middleware('auth')->group(function () {
     // Development debug routes
     if (app()->environment('local')) {
         Route::prefix('debug')->name('debug.')->group(function () {
-            Route::get('/signature', fn() => view('debug.signature'))->name('signature');
-            Route::get('/test-accounts', fn() => view('debug.test-accounts'))->name('test-accounts');
+            Route::get('/signature', fn () => view('debug.signature'))->name('signature');
+            Route::get('/test-accounts', fn () => view('debug.test-accounts'))->name('test-accounts');
         });
     }
 });


### PR DESCRIPTION
## Summary
- add Puskesmas model, migration, and seeder for 27 centers
- allow admins to manage kepala puskesmas signatures and stamps
- link management page from navigation
- rename Puskesmas name field to `nama` to resolve SQL errors
- replace anonymous migration with named class to avoid `return` syntax error
- convert remaining migrations to named classes for compatibility with older PHP versions

## Testing
- `./vendor/bin/pint database/migrations`
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c15294508320b4e383f947c1070d