### PR TITLE
Fix Puskesmas table migration and seeder

### DIFF
--- a/app/Http/Controllers/Admin/PuskesmasController.php
+++ b/app/Http/Controllers/Admin/PuskesmasController.php
@@ -16,19 +16,7 @@ class PuskesmasController extends Controller
 
     public function index()
     {
- 
-        $puskesmas = Puskesmas::orderBy('nama')->get();
- 
- 
-        $puskesmas = Puskesmas::orderBy('nama')->get();
- 
- 
-        $puskesmas = Puskesmas::orderBy('nama')->get();
- 
         $puskesmas = Puskesmas::orderBy('nama_puskesmas')->get();
-  main
- 
- 
 
         return view('admin.puskesmas.index', compact('puskesmas'));
     }

--- a/app/Models/Puskesmas.php
+++ b/app/Models/Puskesmas.php
@@ -10,19 +10,7 @@ class Puskesmas extends Model
     use HasFactory;
 
     protected $fillable = [
- 
-        'nama',
- 
- 
-        'nama',
- 
- 
-        'nama',
- 
         'nama_puskesmas',
- 
- 
- 
         'kepala_puskesmas',
         'nip_kepala',
         'tanda_tangan',

--- a/database/migrations/2025_08_13_015858_create_puskesmas_table.php
+++ b/database/migrations/2025_08_13_015858_create_puskesmas_table.php
@@ -13,19 +13,7 @@ class CreatePuskesmasTable extends Migration
     {
         Schema::create('puskesmas', function (Blueprint $table) {
             $table->id();
- 
-            $table->string('nama');
- 
- 
-            $table->string('nama');
- 
- 
-            $table->string('nama');
- 
             $table->string('nama_puskesmas');
- 
- 
- 
             $table->string('kepala_puskesmas')->nullable();
             $table->string('nip_kepala')->nullable();
             $table->string('tanda_tangan')->nullable();

--- a/database/seeders/PuskesmasSeeder.php
+++ b/database/seeders/PuskesmasSeeder.php
@@ -11,19 +11,7 @@ class PuskesmasSeeder extends Seeder
     {
         for ($i = 1; $i <= 27; $i++) {
             Puskesmas::create([
- 
-                'nama' => 'Puskesmas '.$i,
- 
- 
-                'nama' => 'Puskesmas '.$i,
- 
- 
-                'nama' => 'Puskesmas '.$i,
- 
                 'nama_puskesmas' => 'Puskesmas '.$i,
- 
- 
- 
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- clean up Puskesmas migration to correctly define table columns
- simplify Puskesmas seeder and model fillables
- streamline admin Puskesmas controller index query

## Testing
- `php artisan migrate:fresh --seed --force`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68a7d99acd6c8320a2c823eb4c7997cc