### PR TITLE
Prevent duplicate Puskesmas seed data

### DIFF
--- a/database/seeders/PuskesmasSeeder.php
+++ b/database/seeders/PuskesmasSeeder.php
@@ -10,7 +10,7 @@ class PuskesmasSeeder extends Seeder
     public function run(): void
     {
         for ($i = 1; $i <= 27; $i++) {
-            Puskesmas::create([
+            Puskesmas::firstOrCreate([
                 'nama_puskesmas' => 'Puskesmas '.$i,
             ]);
         }


### PR DESCRIPTION
### **User description**
## Summary
- use `firstOrCreate` in `PuskesmasSeeder` to avoid duplicate entries

## Testing
- `php artisan migrate:fresh --seed --seeder=PuskesmasSeeder --force`
- `php artisan db:seed --class=PuskesmasSeeder --force`
- `sqlite3 database/database.sqlite "SELECT COUNT(*) FROM puskesmas;"`
- `php artisan test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_68a86597c1408320b5b3ea6b8ec4f845


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `create()` with `firstOrCreate()` in PuskesmasSeeder

- Prevent duplicate Puskesmas entries when seeding database


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Database Seeder"] -- "firstOrCreate()" --> B["Puskesmas Table"]
  B -- "Check existing" --> C["No Duplicates"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PuskesmasSeeder.php</strong><dd><code>Replace create with firstOrCreate method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

database/seeders/PuskesmasSeeder.php

<ul><li>Changed <code>Puskesmas::create()</code> to <code>Puskesmas::firstOrCreate()</code><br> <li> Prevents duplicate entries when running seeder multiple times</ul>


</details>


  </td>
  <td><a href="https://github.com/alfarizi-front/laravel-surat-cuti/pull/17/files#diff-0b631e0cf332081190a2e3b1ad24c8f8e364ea883ab6c8adc2980b61cc781417">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

